### PR TITLE
Added code for using FSDKaggle2018 Dataset for Audition tasks.

### DIFF
--- a/benchmarks/audition/toolbox.py
+++ b/benchmarks/audition/toolbox.py
@@ -9,17 +9,84 @@ import os
 import cv2
 import librosa
 import numpy as np
+import matplotlib.pyplot as plt
+import pandas as pd
 from sklearn.metrics import cohen_kappa_score
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
+from torch.utils.data import Dataset
+import torchaudio
 import torchaudio.transforms as trans
 
+class FSDKaggle18Dataset(Dataset):
+  """
+  This class is based on torch.utils.data.Dataset for loading the entire 
+  FSDKaggle18 Dataset using native torch and torchaudio primitives.
 
-def load_spoken_digit(path_recordings, feature_type="spectrogram"):
-    file = os.listdir(path_recordings)
+  ----------------------------------------------------
+  Input parameters:
+    annotations_file: str
+    Path to the file containing the ground truths
+
+    audio_dir: str
+    Path to the folder containing the audio files
+
+  Returns:
+  instance of torch.utils.data.Dataset() returning the audio file together with it's corresponding label.
+
+  """    
+  def __init__(self, annotations_file, audio_dir):
+    #loop through the csv entries and only add entries from folders in the folder list
+    self.annotations = pd.read_csv(annotations_file)
+    self.audio_dir = audio_dir
+    data_final = []
+    for filepaths in os.listdir(self.audio_dir):
+      data_final.append(os.path.join(self.audio_dir,filepaths))
+    self.data_final = data_final
+
+  def __getitem__(self, index):
+    audio_sample_path = self._get_sample_path(index)
+    label = self._get_label_(index)
+    signal, sr = torchaudio.load(audio_sample_path)
+    return signal, sr, label
+  
+  def _get_sample_path(self, index):
+    return os.path.join(self.audio_dir, self.annotations.iloc[index,0])
+
+  def _get_label_(self,index1):
+    labels_to_index = {'Acoustic_guitar': 0, 'Applause': 1, 'Bark': 2, 'Bass_drum': 3, 'Burping_or_eructation': 4, 'Bus': 5, 'Cello': 6, 'Chime': 7, 'Clarinet': 8, 'Computer_keyboard': 9, 'Cough': 10, 'Cowbell': 11, 'Double_bass': 12, 'Drawer_open_or_close': 13, 'Electric_piano': 14, 'Fart': 15, 'Finger_snapping': 16, 'Fireworks': 17, 'Flute': 18, 'Glockenspiel': 19, 'Gong': 20, 'Gunshot_or_gunfire': 21, 'Harmonica': 22, 'Hi-hat': 23, 'Keys_jangling': 24, 'Knock': 25, 'Laughter': 26, 'Meow': 27, 'Microwave_oven': 28, 'Oboe': 29, 'Saxophone': 30, 'Scissors': 31, 'Shatter': 32, 'Snare_drum': 33, 'Squeak': 34, 'Tambourine': 35, 'Tearing': 36, 'Telephone': 37, 'Trumpet': 38, 'Violin_or_fiddle': 39, 'Writing': 40}
+    get_labels = self.annotations['label'].replace(labels_to_index).to_list()
+    y_value = get_labels[index1]
+    return y_value
+
+  def __len__(self):
+    return len(os.listdir(self.audio_dir))
+
+  def plot_waveform(waveform, sample_rate, title="Waveform", xlim=None, ylim=None):
+    waveform = waveform.numpy()
+
+    num_channels, num_frames = waveform.shape
+    time_axis = torch.arange(0, num_frames) / sample_rate
+
+    figure, axes = plt.subplots(num_channels, 1)
+    if num_channels == 1:
+      axes = [axes]
+    for c in range(num_channels):
+      axes[c].plot(time_axis, waveform[c], linewidth=1)
+      axes[c].grid(True)
+      if num_channels > 1:
+        axes[c].set_ylabel(f'Channel {c+1}')
+      if xlim:
+        axes[c].set_xlim(xlim)
+      if ylim:
+        axes[c].set_ylim(ylim)
+    figure.suptitle(title)
+    plt.show(block=False)
+
+def load_spoken_digit(path_recordings, labels_file, label_arr, feature_type="spectrogram"):
 
     audio_data = []  # audio data
     x_spec = []  # STFT spectrogram
@@ -32,24 +99,23 @@ def load_spoken_digit(path_recordings, feature_type="spectrogram"):
         a = trans.MelSpectrogram(n_fft=128, normalized=True)
     elif feature_type == "mfcc":
         a = trans.MFCC(n_mfcc=128)
-    for i in file:
-        x, sr = librosa.load(path_recordings + i, sr=8000)
+    for i in path_recordings:
+        x, sr = librosa.load(i, sr = 44100)
+        i = i[-12:]
         x_stft_db = a(torch.tensor(x)).numpy()
         # Convert an amplitude spectrogram to dB-scaled spectrogram
         x_stft_db_mini = cv2.resize(x_stft_db, (32, 32))  # Resize into 32 by 32
-        y_n = i[0]  # number
-        y_s = i[2]  # first letter of speaker's name
+        get_label_location = int(labels_file.fname.index[labels_file['fname'] == i].to_numpy())
 
+        y_s = label_arr[get_label_location]  # label number
         audio_data.append(x)
         x_spec.append(x_stft_db)
         x_spec_mini.append(x_stft_db_mini)
-        y_number.append(y_n)
-        y_speaker.append(y_s)
+        y_number.append(y_s)
 
     x_spec_mini = np.array(x_spec_mini)
     y_number = np.array(y_number).astype(int)
-    y_speaker = np.array(y_speaker)
-
+    
     return x_spec_mini, y_number
 
 


### PR DESCRIPTION
Added code that uses the [ FSDKaggle2018 Dataset](https://zenodo.org/record/2552860#.YbZRc71KhPa) instead of the FSDD Dataset for audition tasks.

The code addresses the following issues:

- [Issue #42](https://github.com/neurodata/df-dn-paper/issues/42) - Updating the audition codebase for using the new dataset. 
Changes have been made to benchmarks/audition/fsdd.py and benchmarks/audition/toolbox.py file
- [Issue #43](https://github.com/neurodata/df-dn-paper/issues/43) - Creation of a Pytorch native Dataset and DataLoader primitive for the new dataset. 
Changes have been made to the benchmarks/audition/toolbox.py file
